### PR TITLE
Revert "Update aks-pod-identity-assignment.tf"

### DIFF
--- a/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
+++ b/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
@@ -26,7 +26,7 @@ resource "azurerm_role_assignment" "kubelet_noderg_vmcontrib" {
 
 # Separate subnet
 resource "azurerm_role_assignment" "kubelet_subnets_networkcontrib" {
-  for_each = lookup(var.vnets[var.aks_cluster_vnet_key], "subnet_keys", { vnet = true })
+  for_each = toset(lookup(var.vnets[var.aks_cluster_vnet_key], "subnet_keys", [true]))
 
   scope                = try(each.value == true, false) ? local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].id : local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].subnets[each.value].id
   role_definition_name = "Network Contributor"


### PR DESCRIPTION
I made the change before (It used to be like your code) because var.vnets[var.aks_cluster_vnet_key].subnet_keys was a list.
Thus if you supply the above value then we would have the below error.
Reverting this for now as this is breaking one of my customer.

 line 29, in resource "azurerm_role_assignment" "kubelet_subnets_networkcontrib":
│   29:   for_each = lookup(var.vnets[var.aks_cluster_vnet_key], "subnet_keys", { vnet = true })
│     ├────────────────
│     │ var.aks_cluster_vnet_key is "vnet_gitops"
│     │ var.vnets is object with 1 attribute "vnet_gitops"
│ 
│ The given "for_each" argument value is unsuitable: the "for_each" argument
│ must be a map, or set of strings, and you have provided a value of type
│ tuple.
╵