### PR TITLE
feat: azure search services to caf solutions

### DIFF
--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -47,6 +47,7 @@ module "solution" {
   remote_objects                        = local.remote
   resource_groups                       = var.resource_groups
   role_mapping                          = var.role_mapping
+  search_services                       = var.search_services
   security                              = local.security
   shared_services                       = local.shared_services
   storage                               = local.storage

--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -47,7 +47,7 @@ module "solution" {
   remote_objects                        = local.remote
   resource_groups                       = var.resource_groups
   role_mapping                          = var.role_mapping
-  search_services                       = var.search_services
+  search_services                       = local.search_services
   security                              = local.security
   shared_services                       = local.shared_services
   storage                               = local.storage

--- a/caf_solution/local.search_services.tf
+++ b/caf_solution/local.search_services.tf
@@ -1,0 +1,9 @@
+#Terraform AzureRM CAF uses local.search_services.search_services in search_service.tf, need to use locals.
+locals {
+  search_services = merge(
+    var.search_services,
+    {
+      search_services = var.search_services
+    }
+  )
+}

--- a/caf_solution/variables.search_services.tf
+++ b/caf_solution/variables.search_services.tf
@@ -1,0 +1,5 @@
+# Search Servies
+variable "search_services" {
+  description = "Search Service Configration Objects"
+  default = {}
+}

--- a/caf_solution/variables.tf
+++ b/caf_solution/variables.tf
@@ -265,3 +265,8 @@ variable "random_strings" {
 variable "data_sources" {
   default = {}
 }
+
+variable "search_services" {
+  description = "Search service Configration Objects"
+  default = {}
+}

--- a/caf_solution/variables.tf
+++ b/caf_solution/variables.tf
@@ -265,8 +265,3 @@ variable "random_strings" {
 variable "data_sources" {
   default = {}
 }
-
-variable "search_services" {
-  description = "Search service Configration Objects"
-  default = {}
-}


### PR DESCRIPTION
# [Issue-id: 526](https://github.com/Azure/caf-terraform-landingzones/issues/526)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Azurerm_search_services added to [terraform-azurerm-caf](https://github.com/aztfmod/terraform-azurerm-caf) in PR https://github.com/aztfmod/terraform-azurerm-caf/pull/1907.
however, CAF Solutions isn't supporting the search_services module.
<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
Using one of the examples in [terraform-azurerm-caf-search-services-examples](https://github.com/leelasatyavathip/terraform-azurerm-caf/tree/main/examples/search_service) should be enough to testing.
